### PR TITLE
fix: fetcher cache poisoning + raw.githubusercontent.com switch (closes #2)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@eevenson/architect-knowledge-mcp",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@eevenson/architect-knowledge-mcp",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eevenson/architect-knowledge-mcp",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "MCP server for the Architect knowledge library — cloud architecture checklists, vendor guidance, and compliance frameworks",
   "type": "module",
   "bin": {

--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -2,17 +2,42 @@
  * Fetches knowledge files from the public GitHub repository.
  * Only reads from the knowledge/ directory — never touches client data,
  * uploads, or any other content.
+ *
+ * Fetch strategy:
+ * - Uses raw.githubusercontent.com (no API rate limit) for file content,
+ *   so anonymous users can complete a full fetch without GITHUB_TOKEN.
+ * - Uses the GitHub API only for two calls per refresh: latest commit SHA
+ *   and the recursive tree listing. Both fit comfortably in the anonymous
+ *   60 req/hour quota.
+ *
+ * Cache safety:
+ * - All files are downloaded into memory first; the on-disk cache and
+ *   manifest are only updated if every file fetch succeeded.
+ * - 404 on a file is treated as "deleted upstream" — the file is dropped
+ *   from the result set but the fetch is not aborted.
+ * - 429 / 5xx / network errors abort the entire fetch and leave the
+ *   previous cache untouched, so the next startup retries cleanly.
+ * - The manifest is written via a temp file + rename so the freshness
+ *   check never sees a half-written manifest.
  */
 
 import { createHash } from "node:crypto";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
 
 const REPO_OWNER = "ErikEvenson";
 const REPO_NAME = "architect";
+const REPO_BRANCH = "master";
 const KNOWLEDGE_PATH = "knowledge";
 const GITHUB_API = "https://api.github.com";
+const GITHUB_RAW = "https://raw.githubusercontent.com";
 
 // Allowlisted directories within knowledge/ — only these are fetched
 const ALLOWED_DIRS = [
@@ -50,6 +75,13 @@ interface CacheManifest {
   fileCount: number;
 }
 
+class RateLimitError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "RateLimitError";
+  }
+}
+
 function getCacheDir(): string {
   const dir = join(homedir(), ".cache", "architect-knowledge-mcp");
   if (!existsSync(dir)) {
@@ -63,7 +95,10 @@ function getCacheManifestPath(): string {
 }
 
 function getCacheFilePath(relativePath: string): string {
-  const hash = createHash("sha256").update(relativePath).digest("hex").slice(0, 16);
+  const hash = createHash("sha256")
+    .update(relativePath)
+    .digest("hex")
+    .slice(0, 16);
   return join(getCacheDir(), `${hash}.md`);
 }
 
@@ -77,8 +112,13 @@ function readCacheManifest(): CacheManifest | null {
   }
 }
 
-function writeCacheManifest(manifest: CacheManifest): void {
-  writeFileSync(getCacheManifestPath(), JSON.stringify(manifest, null, 2));
+function writeCacheManifestAtomic(manifest: CacheManifest): void {
+  // Write to a temp file and rename so a partial write never poisons the
+  // freshness check on subsequent startups.
+  const finalPath = getCacheManifestPath();
+  const tmpPath = `${finalPath}.tmp`;
+  writeFileSync(tmpPath, JSON.stringify(manifest, null, 2));
+  renameSync(tmpPath, finalPath);
 }
 
 function isAllowedPath(filePath: string): boolean {
@@ -91,13 +131,14 @@ function isAllowedPath(filePath: string): boolean {
   return ALLOWED_DIRS.includes(topDir);
 }
 
-async function githubFetch(url: string): Promise<Response> {
+async function githubApiFetch(url: string): Promise<Response> {
   const headers: Record<string, string> = {
     Accept: "application/vnd.github.v3+json",
     "User-Agent": "architect-knowledge-mcp",
   };
 
-  // Use GITHUB_TOKEN if available (for rate limiting)
+  // GITHUB_TOKEN is optional — used only for the 2 API calls per refresh
+  // (latest commit SHA, recursive tree). Raw file fetches do not need it.
   const token = process.env.GITHUB_TOKEN;
   if (token) {
     headers.Authorization = `Bearer ${token}`;
@@ -106,35 +147,42 @@ async function githubFetch(url: string): Promise<Response> {
   return fetch(url, { headers });
 }
 
+async function rawFetch(commitSha: string, relativePath: string): Promise<Response> {
+  const url = `${GITHUB_RAW}/${REPO_OWNER}/${REPO_NAME}/${commitSha}/${KNOWLEDGE_PATH}/${relativePath}`;
+  return fetch(url, {
+    headers: { "User-Agent": "architect-knowledge-mcp" },
+  });
+}
+
 async function getLatestCommitSha(): Promise<string> {
-  const resp = await githubFetch(
-    `${GITHUB_API}/repos/${REPO_OWNER}/${REPO_NAME}/commits/master?per_page=1`
+  const resp = await githubApiFetch(
+    `${GITHUB_API}/repos/${REPO_OWNER}/${REPO_NAME}/commits/${REPO_BRANCH}?per_page=1`,
   );
+  if (resp.status === 429 || resp.status === 403) {
+    throw new RateLimitError(
+      `GitHub API rate-limited fetching latest commit SHA (HTTP ${resp.status}). ` +
+        `Set GITHUB_TOKEN to raise the limit.`,
+    );
+  }
   if (!resp.ok) {
-    throw new Error(`Failed to get latest commit: ${resp.status} ${resp.statusText}`);
+    throw new Error(
+      `Failed to get latest commit: ${resp.status} ${resp.statusText}`,
+    );
   }
   const data = (await resp.json()) as { sha: string };
   return data.sha;
 }
 
-async function fetchFileContent(filePath: string): Promise<string> {
-  const resp = await githubFetch(
-    `${GITHUB_API}/repos/${REPO_OWNER}/${REPO_NAME}/contents/${KNOWLEDGE_PATH}/${filePath}`
-  );
-  if (!resp.ok) {
-    throw new Error(`Failed to fetch ${filePath}: ${resp.status}`);
-  }
-  const data = (await resp.json()) as { content: string; encoding: string };
-  if (data.encoding === "base64") {
-    return Buffer.from(data.content, "base64").toString("utf-8");
-  }
-  return data.content;
-}
-
 async function fetchTree(commitSha: string): Promise<GitHubTreeItem[]> {
-  const resp = await githubFetch(
-    `${GITHUB_API}/repos/${REPO_OWNER}/${REPO_NAME}/git/trees/${commitSha}?recursive=1`
+  const resp = await githubApiFetch(
+    `${GITHUB_API}/repos/${REPO_OWNER}/${REPO_NAME}/git/trees/${commitSha}?recursive=1`,
   );
+  if (resp.status === 429 || resp.status === 403) {
+    throw new RateLimitError(
+      `GitHub API rate-limited fetching tree (HTTP ${resp.status}). ` +
+        `Set GITHUB_TOKEN to raise the limit.`,
+    );
+  }
   if (!resp.ok) {
     throw new Error(`Failed to fetch tree: ${resp.status}`);
   }
@@ -142,79 +190,131 @@ async function fetchTree(commitSha: string): Promise<GitHubTreeItem[]> {
   return data.tree;
 }
 
+/**
+ * Fetches a single file's raw content. Returns null when the file no
+ * longer exists upstream (404). Throws on any other error so the caller
+ * can abort the entire refresh.
+ */
+async function fetchFileContent(
+  commitSha: string,
+  relativePath: string,
+): Promise<string | null> {
+  const resp = await rawFetch(commitSha, relativePath);
+  if (resp.status === 404) {
+    // File was removed upstream — drop it from the result set but do not
+    // abort the refresh.
+    return null;
+  }
+  if (resp.status === 429) {
+    // raw.githubusercontent.com is not normally rate-limited, but if it
+    // ever returns 429 we surface it explicitly so we don't poison the cache.
+    throw new RateLimitError(
+      `raw.githubusercontent.com rate-limited fetching ${relativePath} (HTTP 429). ` +
+        `Aborting refresh; previous cache will be reused on next startup.`,
+    );
+  }
+  if (!resp.ok) {
+    throw new Error(`Failed to fetch ${relativePath}: ${resp.status} ${resp.statusText}`);
+  }
+  return await resp.text();
+}
+
 export async function fetchKnowledgeFiles(): Promise<KnowledgeFile[]> {
   const cacheDir = getCacheDir();
   const manifest = readCacheManifest();
 
-  // Check if cache is fresh
+  // Resolve the latest commit SHA. If GitHub API is unreachable or
+  // rate-limited and we have a cache, fall back to it.
   let latestSha: string;
   try {
     latestSha = await getLatestCommitSha();
-  } catch {
-    // Offline or rate-limited — use cache if available
+  } catch (err) {
     if (manifest) {
-      console.error("GitHub API unavailable, using cached knowledge files");
+      console.error(
+        `GitHub API unavailable (${(err as Error).message}), using cached knowledge files`,
+      );
       return loadFromCache();
     }
-    throw new Error("Cannot fetch knowledge files and no cache available");
+    throw new Error(
+      `Cannot fetch knowledge files and no cache available: ${(err as Error).message}`,
+    );
   }
 
   if (manifest && manifest.commitSha === latestSha) {
-    console.error(`Knowledge cache is fresh (${latestSha.slice(0, 7)}), using cached files`);
+    console.error(
+      `Knowledge cache is fresh (${latestSha.slice(0, 7)}), using cached files`,
+    );
     return loadFromCache();
   }
 
-  console.error(`Fetching knowledge files from GitHub (${latestSha.slice(0, 7)})...`);
+  console.error(
+    `Fetching knowledge files from GitHub (${latestSha.slice(0, 7)})...`,
+  );
 
-  // Get full tree to find all knowledge files
+  // Get the recursive tree (1 API call) to enumerate knowledge files.
   const tree = await fetchTree(latestSha);
   const knowledgeFiles = tree.filter(
     (item) =>
       item.type === "blob" &&
       item.path.startsWith(`${KNOWLEDGE_PATH}/`) &&
-      isAllowedPath(item.path.slice(KNOWLEDGE_PATH.length + 1))
+      isAllowedPath(item.path.slice(KNOWLEDGE_PATH.length + 1)),
   );
 
+  // Phase 1: download every file into memory. Abort on the first non-404
+  // failure so we never persist a partial cache.
   const files: KnowledgeFile[] = [];
-  const batchSize = 10;
+  const batchSize = 20; // raw.githubusercontent.com has no rate limit, so we can be more parallel
+  let droppedCount = 0;
 
-  for (let i = 0; i < knowledgeFiles.length; i += batchSize) {
-    const batch = knowledgeFiles.slice(i, i + batchSize);
-    const results = await Promise.all(
-      batch.map(async (item) => {
-        const relativePath = item.path.slice(KNOWLEDGE_PATH.length + 1);
-        try {
-          const content = await fetchFileContent(relativePath);
-          return { path: relativePath, content };
-        } catch (err) {
-          console.error(`Warning: failed to fetch ${relativePath}: ${err}`);
-          return null;
+  try {
+    for (let i = 0; i < knowledgeFiles.length; i += batchSize) {
+      const batch = knowledgeFiles.slice(i, i + batchSize);
+      const results = await Promise.all(
+        batch.map(async (item) => {
+          const relativePath = item.path.slice(KNOWLEDGE_PATH.length + 1);
+          const content = await fetchFileContent(latestSha, relativePath);
+          return content === null ? null : { path: relativePath, content };
+        }),
+      );
+      for (const result of results) {
+        if (result === null) {
+          droppedCount++;
+        } else {
+          files.push(result);
         }
-      })
-    );
-
-    for (const result of results) {
-      if (result) {
-        files.push(result);
-        // Cache each file
-        const cachePath = getCacheFilePath(result.path);
-        writeFileSync(cachePath, JSON.stringify(result));
       }
     }
+  } catch (err) {
+    // Any non-404 failure aborts the refresh. The previous manifest and
+    // cache files on disk are unchanged, so the next startup will retry.
+    console.error(
+      `Aborting refresh — ${(err as Error).message}. ` +
+        `Previous cache (commit ${manifest?.commitSha.slice(0, 7) ?? "none"}) preserved.`,
+    );
+    if (manifest) {
+      return loadFromCache();
+    }
+    throw err;
   }
 
-  // Write cache manifest
-  writeCacheManifest({
+  // Phase 2: persist to disk. Files are written first, then index.json,
+  // then the manifest LAST (atomically) so a crash mid-write cannot leave
+  // the freshness check thinking we have content we don't.
+  for (const file of files) {
+    writeFileSync(getCacheFilePath(file.path), JSON.stringify(file));
+  }
+  const index = files.map((f) => f.path);
+  writeFileSync(join(cacheDir, "index.json"), JSON.stringify(index));
+  writeCacheManifestAtomic({
     commitSha: latestSha,
     fetchedAt: new Date().toISOString(),
     fileCount: files.length,
   });
 
-  // Write file index for cache loading
-  const index = files.map((f) => f.path);
-  writeFileSync(join(cacheDir, "index.json"), JSON.stringify(index));
-
-  console.error(`Cached ${files.length} knowledge files`);
+  console.error(
+    `Cached ${files.length} knowledge files` +
+      (droppedCount > 0 ? ` (${droppedCount} files were 404 and dropped)` : ""),
+  );
   return files;
 }
 


### PR DESCRIPTION
## Summary

Fixes the P0 cache-poisoning bug reported in #2. Two changes that together prevent silent partial caches and let anonymous users complete a full fetch reliably.

### 1. Switch file content fetches to \`raw.githubusercontent.com\`

The previous code used \`GET /repos/{owner}/{repo}/contents/{path}\` once per file. With ~338 knowledge files and a 60 req/hour anonymous quota, **a complete fetch was mathematically impossible** without \`GITHUB_TOKEN\`. The new code fetches file content from \`https://raw.githubusercontent.com/{owner}/{repo}/{sha}/{path}\`, which has no API rate limit.

The GitHub API is still used for the two metadata calls per refresh (latest commit SHA + recursive tree). Both fit comfortably in the anonymous quota for typical use.

### 2. All-or-nothing cache semantics

Previously, per-file 429 errors were caught and swallowed but the cache manifest was still written with the new commit SHA. The result: a silently partial cache that the freshness check then treated as up-to-date forever.

The new code:
- Downloads every file into memory first.
- 404 on a single file is treated as \"deleted upstream\" — dropped from the result set, fetch continues.
- Any other failure (429, 5xx, network) aborts the refresh and leaves the previous on-disk cache untouched.
- Files are persisted to disk only if every fetch succeeded.
- The manifest is written via temp file + atomic rename so a crash mid-write cannot leave a half-written manifest.
- A new \`RateLimitError\` class makes 429/403 responses explicit and points users at \`GITHUB_TOKEN\` as the workaround.

### 3. Other small improvements

- Hoisted the branch name (\`master\`) into a \`REPO_BRANCH\` constant.
- Bumped batch size from 10 to 20 (raw host has no rate limit, so we can be more parallel).
- Logs now distinguish \"cached N files\" from \"cached N files (M dropped as 404)\".

## Verification

Tested end-to-end against \`ErikEvenson/architect@d7bfb3c\` from a clean cache.

### Sad path — no token, API rate-limited

\`\`\`
$ rm -rf ~/.cache/architect-knowledge-mcp
$ node build/index.js
Architect Knowledge MCP server started
Failed to initialize knowledge library: Error: Cannot fetch knowledge files
  and no cache available: GitHub API rate-limited fetching latest commit SHA
  (HTTP 403). Set GITHUB_TOKEN to raise the limit.

$ ls ~/.cache/architect-knowledge-mcp/
(empty — no manifest written, no cache files)
\`\`\`

**Old behavior:** would have written a 58-file partial cache claiming the new SHA → silent corruption forever.
**New behavior:** clean abort with an actionable error.

### Happy path — with token

\`\`\`
$ rm -rf ~/.cache/architect-knowledge-mcp
$ GITHUB_TOKEN=... node build/index.js
Architect Knowledge MCP server started
Fetching knowledge files from GitHub (d7bfb3c)...
Cached 338 knowledge files
Indexed 8829 chunks from 338 knowledge files

$ cat ~/.cache/architect-knowledge-mcp/manifest.json
{
  \"commitSha\": \"d7bfb3c9ff0d9a7dfc3bce5530fd4ae47b07c1a7\",
  \"fetchedAt\": \"2026-04-07T21:30:36.915Z\",
  \"fileCount\": 338
}

$ ls ~/.cache/architect-knowledge-mcp/*.md | wc -l
338
\`\`\`

| Metric | Old fetcher (poisoned) | New fetcher |
|---|---|---|
| Files cached | 58 | **338** |
| AWS provider files | 1 | **30** |
| \`providers/aws/networking.md\` | missing | **present** |
| Chunks indexed | 3,030 | **8,829** |
| Behavior on 429 | silent partial cache | **clean abort, cache preserved** |

I also confirmed that the new AWS PrivateLink content from \`ErikEvenson/architect@f93dc45\` (\`endpoint service\`, \`GWLBe\`) is present in the cache and indexed. That content was the original motivation for filing the bug — it could not reach MCP users with the old fetcher.

## Test plan
- [x] \`npm run build\` — clean
- [x] Sad path: clean cache, no token, API rate-limited → no manifest written, no cache files, clean error
- [x] Happy path: clean cache, with token → 338 files cached, 8829 chunks indexed, manifest reflects state
- [x] AWS PrivateLink content (commit f93dc45) verified present in cache
- [ ] After merge: \`npm publish --access public\` to release \`0.1.1\` to npm (no CI release workflow exists in this repo)
- [ ] After publish: confirm \`npx -y @eevenson/architect-knowledge-mcp@0.1.1 </dev/null\` works on a clean machine

## Notes for the maintainer

- **Manual publish required.** The repo has no \`.github/workflows/\` directory, so merging this PR will not auto-publish to npm. You'll need to run \`npm publish --access public\` after merging. If you want, I can open a follow-up PR adding a release workflow that publishes on tag.
- **Existing users with poisoned caches.** Anyone running the old version today has a partially-poisoned cache at \`~/.cache/architect-knowledge-mcp/\`. After upgrading, that stale cache will only be replaced when a new commit lands on \`master\` (because the SHA-equality check still passes against the old SHA). A more aggressive fix would invalidate caches whose \`fileCount\` is suspiciously low. I deliberately did not add that here to keep the diff focused; happy to do it as a follow-up if you want.
- **Version bump.** Patch bump from \`0.1.0\` → \`0.1.1\` since this is a backwards-compatible bug fix.

## Related
- ErikEvenson/architect-knowledge-mcp#1 — refresh enhancements (periodic refresh, refresh tool, status tool). The status tool from #1 should report \`fetch_complete: true\` (always now, after this PR) and the cached \`commitSha\`.
- ErikEvenson/architect#221 — separate but adjacent: malformed URLs in source knowledge files cause vendor-fetch failures on the architect backend. Different repo, different failure mode.